### PR TITLE
Reduced minimum track size to support smaller windows

### DIFF
--- a/BlurryWindow/Helper/SizeHelper.cs
+++ b/BlurryWindow/Helper/SizeHelper.cs
@@ -132,8 +132,8 @@ namespace BlurryControls.Helper
                 mmi.ptMaxSize.y = Math.Abs(rcWorkArea.right - rcMonitorArea.left);
                 mmi.ptMaxTrackSize.x = mmi.ptMaxSize.x;
                 mmi.ptMaxTrackSize.y = mmi.ptMaxSize.y;
-                mmi.ptMinTrackSize.x = 100;
-                mmi.ptMinTrackSize.y = 100;
+                mmi.ptMinTrackSize.x = 20;
+                mmi.ptMinTrackSize.y = 20;
                 mmi = AdjustWorkingAreaForAutoHide(monitorContainingApplication, mmi);
             }
             Marshal.StructureToPtr(mmi, lParam, true);


### PR DESCRIPTION
Just had a problem resizing programmatically my window to height 65. The window just continued snapping back to 100. 